### PR TITLE
Immigrate the dockerfile from the pipeline's repo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,30 +8,5 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
-### Changed
-- Changed something but it is not part of the last release.
-
----
-
-## [1.0.0] - YYYY-MM-DD
 ### Added
-- For new features.
-- Added item 1.
-
-### Changed
-- For changes in existing functionality.
-- Changed item 1.
-
-### Deprecated
-- For soon-to-be removed features.
-
-### Removed
-- For now removed features.
-- Removed item 1.
-
-### Fixed
-- For any bug fixes.
-- Fixed item 1.
-
-### Security
-- In case of vulnerabilities.
+- Added the Dockerfile for FusionCatcher, immigrated from the original call-FusionTranscript pipeline repo.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,58 @@
 FROM blcdsdockerregistry/bl-base:1.0.0 AS builder
 
-# Use conda to install tools and dependencies into /usr/local
-ARG TOOL_VERSION=X.X.X
-RUN conda create -qy -p /usr/local \
-    -c bioconda \
-    -c conda-forge \
-    tool_name==${TOOL_VERSION}
+# This dockerfile is written in this way, that I use a environment.yaml to manage dependencies, and
+# download the tarball from github releases. The reason that it's not directly installing from conda
+# is that the bioconda recipe for version 1.33 isn't configured correctly. In the future versions,
+# or if the bioconda recipe is fixed, we may consider just directly install from it.
+
+COPY environment.yaml /opt
+COPY build.sh /opt
+COPY download-human-db.sh /opt
+
+ENV FUSIONCATCHER_VERSION=1.33
+ENV FUSIONCATCHER_SHA512=1d39aa154d6018ecb3f4cb1296e404a36edd2464e86b24e5c0fe70ac3f5d5c84cb1be50ac027f3b627b2d7972689527e06a3483be1873a4d43ed14a651a54ba8
+ENV FASTQTK_VERSION=0.27
+ENV FASTQTK_SHA512=cf4eb4f057b427cd09c28fa7890bee34db5c475039adaaca53c408a857b3d0640f7a245ff388cee6d8c98f8ddf6bd624a4621c96ef3fcfe1a4b48ae069a882e6
+ENV CONDA_PREFIX=/usr/local
+
+RUN conda update -n base -c defaults conda && \
+    conda env create -f /opt/environment.yaml --prefix ${CONDA_PREFIX}
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cd /opt && \
+    wget https://github.com/ndaniel/fusioncatcher/archive/${FUSIONCATCHER_VERSION}.tar.gz && \
+    echo "${FUSIONCATCHER_SHA512} ${FUSIONCATCHER_VERSION}.tar.gz" | sha512sum --strict -c - && \
+    tar -zxf ${FUSIONCATCHER_VERSION}.tar.gz && \
+    cd fusioncatcher-${FUSIONCATCHER_VERSION} && \
+    mv ../build.sh ./ && mv ../download-human-db.sh ./ && \
+    bash build.sh
+
+# fastqtk was added in v1.33. The package is not available on bioconda yet.
+RUN cd /opt && \
+    wget https://github.com/ndaniel/fastqtk/archive/refs/tags/v${FASTQTK_VERSION}.tar.gz && \
+    echo "${FASTQTK_SHA512} v${FASTQTK_VERSION}.tar.gz" | sha512sum --strict -c - && \
+    tar -zxf v${FASTQTK_VERSION}.tar.gz && \
+    cd fastqtk-${FASTQTK_VERSION} && \
+    make && \
+    mv fastqtk /usr/local/bin/
+
+# fix error: faToTwoBit: error while loading shared libraries: libssl.so.1.0.0: cannot open shared
+# object file
+# https://github.com/ndaniel/fusioncatcher/issues/110
+RUN ln -s ${CONDA_PREFIX}/lib/libssl.so.1.1 ${CONDA_PREFIX}/lib/libssl.so.1.0.0 && \
+    ln -s ${CONDA_PREFIX}/lib/libcrypto.so.1.1 ${CONDA_PREFIX}/lib/libcrypto.so.1.0.0
+
 
 # Deploy the target tools into a base image
 FROM ubuntu:20.04
 COPY --from=builder /usr/local /usr/local
 
-LABEL maintainer="Your Name <YourName@mednet.ucla.edu>"
+# ps and command for reporting mertics 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y procps && \
+    rm -rf /var/lib/apt/lists/*
+
+LABEL maintainer="Chenghao Zhu <ChenghaoZhu@mednet.ucla.edu>"

--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
-# docker-tool_name
-Template Repository for the Boutros Lab Dockerfiles based on the bl-base image.
+# docker-FusionCatcher
 
-The bl-base image is located in the Boutros Lab Docker Hub repo: https://hub.docker.com/repository/docker/blcdsdockerregistry/bl-base
+Dockerfile for FusionCatcher, a gene fusion caller from RNA-seq data.
+
+The docker image is available at [blcdsdockerregistry/fusioncatcher](https://hub.docker.com/r/blcdsdockerregistry/fusioncatcher)
 
 # Documentation
-Docker introduction [here](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+Introduction)
 
-Dockerfile Best Practices [here](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Dockerfile+Best+Practices)
-
-Docker image versioning standard [here](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization)
-
+See FusionCatcher's [doc](https://github.com/ndaniel/fusioncatcher/blob/master/doc/manual.md)
 
 # Version
+
 | Tool | Version |
 |------|---------|
-|tool_name| X.X.X|
-|tool_name_2|X.X.X|
-
+|fusioncatcher| 1.33 |
 
 ---
 
 ## References
 
-1. Tool specific references can be listed here
+1. D. Nicorici, M. Satalan, H. Edgren, S. Kangaspeska, A. Murumagi, O. Kallioniemi, S. Virtanen, O. Kilkku, FusionCatcher – a tool for finding somatic fusion genes in paired-end RNA-sequencing data, *bioRxiv*, Nov. 2014, DOI:10.1101/011650

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+PREFIX="/usr/local"
+
+# copy main scripts
+mkdir -p ${PREFIX}/bin
+mkdir -p ${PREFIX}/etc
+mkdir -p ${PREFIX}/doc
+chmod +x bin/*.py
+cp bin/* ${PREFIX}/bin/
+cp etc/configuration.cfg ${PREFIX}/etc/
+cp doc/* ${PREFIX}/doc/
+
+# copy script to download database
+chmod +x download-human-db.sh
+cp download-human-db.sh ${PREFIX}/bin

--- a/download-human-db.sh
+++ b/download-human-db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# FusionCatcher v1.20 uses Human Ensembl v98
+echo "Downloading Human Ensembl v98 database to ${FC_DB_PATH}/current/..."
+
+# Direct download:
+cd ${FC_DB_PATH}
+rm -rf human*.tar.gz.*
+
+wget --no-check-certificate http://sourceforge.net/projects/fusioncatcher/files/data/human_v102.tar.gz.aa -O human_v102.tar.gz.aa
+wget --no-check-certificate http://sourceforge.net/projects/fusioncatcher/files/data/human_v102.tar.gz.ab -O human_v102.tar.gz.ab
+wget --no-check-certificate http://sourceforge.net/projects/fusioncatcher/files/data/human_v102.tar.gz.ac -O human_v102.tar.gz.ac
+wget --no-check-certificate http://sourceforge.net/projects/fusioncatcher/files/data/human_v102.tar.gz.ad -O human_v102.tar.gz.ad
+
+cat human_v102.tar.gz.* | tar xz
+ln -s human_v102 current
+
+echo "Human Ensembl v98 database is downloaded."
+
+exit 0

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,35 @@
+---
+name: fusioncatcher
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - python=2.7
+  - biopython >=1.50
+  - bowtie=1.2.3
+  - fusioncatcher-seqtk=1.2
+  - star=2.7.2b
+  - bowtie2=2.3.5
+  - bbmap=38.44
+  - blat=35
+  - lzo
+  - bwa=0.7.12
+  - ucsc-faToTwoBit
+  - velvet=1.2.10
+  - openpyxl=2.5.0a2
+  - xlrd=1.0.0
+  - pigz=2.3
+  - samtools=0.1.19
+  - picard=2.10.6
+  - numpy=1.13.1
+  - parallel=20171222
+  - ucsc-liftover
+  - oases
+  - lzop
+  - openjdk
+  - sra-tools=2.9.6
+  - zip
+  - coreutils
+  - grep
+  - wget

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,11 +1,11 @@
 ---
 Category: 'docker'
-Description: 'Template Docker repository for tool_name'  # Description of why the repository exists
-Maintainers: ['YourName@mednet.ucla.edu']  # email address of maintainers
-Contributors: ['Your Name']  # Full names of contributors
-Languages: ['bash']  # programming languages used
-Tools: ['tool_name']  # Name of the tool(s) used in the Dockerfile
-Version: ['X.X.X']  # Tool version number
-Purpose of tool: ''  # Description of what this tool does
-Dependencies: ['docker', 'conda', 'bl-base']  # packages, tools that repo needs to run
-References: ''  # is the tool/dependencies published, is there a confluence page
+Description: 'Repo for the Dockerfile of the FusionCatcher docker image'
+Maintainers: ['ChenghaoZhu@mednet.ucla.edu']
+Contributors: ['Chenghao Zhu']
+Languages: ['Dockerfile']
+Tools: ['FusionCatcher']
+Version: ['1.33']
+Purpose of tool: 'Call gene fusion events from RNA-seq data'
+Dependencies: ['docker', 'bl-base']
+References: '10.1101/011650'


### PR DESCRIPTION
The Dockerfile is moved from it's original location at: https://github.com/uclahs-cds/pipeline-call-FusionTranscript/blob/bbbac6f7e1e1e440140cbc465ce371bf5b1459ac/docker/fusioncatcher/Dockerfile

In this dockerfile, I'm using conda to manage dependencies for FusionCatcher, and then download the tarball from github release directly. The reason for this is the bioconda's recipe for fusioncatcher-1.33 isn't set up correctly.